### PR TITLE
Support for board without SD_DETECT_PIN

### DIFF
--- a/Marlin/src/lcd/extui/lib/dgus_reloaded/DGUSRxHandler.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus_reloaded/DGUSRxHandler.cpp
@@ -47,21 +47,21 @@ void DGUSRxHandler::ScreenChange(DGUS_VP &vp, void *data_ptr) {
   if (vp.addr == DGUS_Addr::SCREENCHANGE_SD) {
     bool return_flag = true;
 
-  #if ENABLED(SDSUPPORT)
-    if (!ExtUI::isMediaInserted()) {
-      if (IS_SD_INSERTED() && !card.isMounted()) {
+    #if ENABLED(SDSUPPORT)
+      #if PIN_EXISTS(SD_DETECT)
+        if (ExtUI::isMediaInserted()) {
+          return_flag = false;
+        }
+      #else
+        card.release();
         card.mount();
         
         if (ExtUI::isMediaInserted()) {
           return_flag = false;
           dgus_screen_handler.SetStatusMessagePGM(GET_TEXT(MSG_MEDIA_INSERTED));
         }
-      }
-    }
-    else {
-      return_flag = false;
-    }
-  #endif
+      #endif
+    #endif
 
     if (return_flag) {
       dgus_screen_handler.SetStatusMessagePGM(GET_TEXT(MSG_NO_MEDIA));

--- a/Marlin/src/lcd/extui/lib/dgus_reloaded/DGUSRxHandler.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus_reloaded/DGUSRxHandler.cpp
@@ -45,19 +45,28 @@ void DGUSRxHandler::ScreenChange(DGUS_VP &vp, void *data_ptr) {
   const DGUS_Screen screen = (DGUS_Screen)((uint8_t*)data_ptr)[1];
 
   if (vp.addr == DGUS_Addr::SCREENCHANGE_SD) {
+    bool return_flag = true;
+
   #if ENABLED(SDSUPPORT)
     if (!ExtUI::isMediaInserted()) {
-      card.mount();
-      if (!ExtUI::isMediaInserted()) {
-        dgus_screen_handler.SetStatusMessagePGM(GET_TEXT(MSG_NO_MEDIA));
-        return;
+      if (IS_SD_INSERTED() && !card.isMounted()) {
+        card.mount();
+        
+        if (ExtUI::isMediaInserted()) {
+          return_flag = false;
+          dgus_screen_handler.SetStatusMessagePGM(GET_TEXT(MSG_MEDIA_INSERTED));
+        }
       }
-      dgus_screen_handler.SetStatusMessagePGM(GET_TEXT(MSG_MEDIA_INSERTED));
     }
-  #else
-    dgus_screen_handler.SetStatusMessagePGM(GET_TEXT(MSG_NO_MEDIA));
-    return;
+    else {
+      return_flag = false;
+    }
   #endif
+
+    if (return_flag) {
+      dgus_screen_handler.SetStatusMessagePGM(GET_TEXT(MSG_NO_MEDIA));
+      return;
+    }
   }
 
   if (vp.addr == DGUS_Addr::SCREENCHANGE_Idle

--- a/Marlin/src/lcd/extui/lib/dgus_reloaded/DGUSRxHandler.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus_reloaded/DGUSRxHandler.cpp
@@ -44,13 +44,20 @@
 void DGUSRxHandler::ScreenChange(DGUS_VP &vp, void *data_ptr) {
   const DGUS_Screen screen = (DGUS_Screen)((uint8_t*)data_ptr)[1];
 
-  if (vp.addr == DGUS_Addr::SCREENCHANGE_SD
-    #if ENABLED(SDSUPPORT)
-      && !ExtUI::isMediaInserted()
-    #endif
-  ) {
+  if (vp.addr == DGUS_Addr::SCREENCHANGE_SD) {
+  #if ENABLED(SDSUPPORT)
+    if (!ExtUI::isMediaInserted()) {
+      card.mount();
+      if (!ExtUI::isMediaInserted()) {
+        dgus_screen_handler.SetStatusMessagePGM(GET_TEXT(MSG_NO_MEDIA));
+        return;
+      }
+      dgus_screen_handler.SetStatusMessagePGM(GET_TEXT(MSG_MEDIA_INSERTED));
+    }
+  #else
     dgus_screen_handler.SetStatusMessagePGM(GET_TEXT(MSG_NO_MEDIA));
     return;
+  #endif
   }
 
   if (vp.addr == DGUS_Addr::SCREENCHANGE_Idle

--- a/Marlin/src/lcd/extui/lib/dgus_reloaded/DGUSRxHandler.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus_reloaded/DGUSRxHandler.cpp
@@ -45,28 +45,21 @@ void DGUSRxHandler::ScreenChange(DGUS_VP &vp, void *data_ptr) {
   const DGUS_Screen screen = (DGUS_Screen)((uint8_t*)data_ptr)[1];
 
   if (vp.addr == DGUS_Addr::SCREENCHANGE_SD) {
-    bool return_flag = true;
-
     #if ENABLED(SDSUPPORT)
-      #if PIN_EXISTS(SD_DETECT)
-        if (ExtUI::isMediaInserted()) {
-          return_flag = false;
-        }
-      #else
-        card.release();
+      #if !PIN_EXISTS(SD_DETECT)
         card.mount();
-        
-        if (ExtUI::isMediaInserted()) {
-          return_flag = false;
-          dgus_screen_handler.SetStatusMessagePGM(GET_TEXT(MSG_MEDIA_INSERTED));
-        }
       #endif
-    #endif
 
-    if (return_flag) {
+      if (!ExtUI::isMediaInserted()) {
+        dgus_screen_handler.SetStatusMessagePGM(GET_TEXT(MSG_NO_MEDIA));
+        return;
+      }
+
+      card.cdroot();
+    #else
       dgus_screen_handler.SetStatusMessagePGM(GET_TEXT(MSG_NO_MEDIA));
       return;
-    }
+    #endif
   }
 
   if (vp.addr == DGUS_Addr::SCREENCHANGE_Idle


### PR DESCRIPTION
This PR allows your fw to works with board without SD_DETECT_PIN. This is also helpful in case of SD external cable. With theese kind of cables the mechanic insertion of sd cards is not detected.