### PR TITLE
Release SD card when not used

### DIFF
--- a/Marlin/src/lcd/extui/lib/dgus_reloaded/DGUSRxHandler.cpp
+++ b/Marlin/src/lcd/extui/lib/dgus_reloaded/DGUSRxHandler.cpp
@@ -62,6 +62,12 @@ void DGUSRxHandler::ScreenChange(DGUS_VP &vp, void *data_ptr) {
     #endif
   }
 
+  #if ENABLED(SDSUPPORT) && PIN_EXISTS(SD_DETECT)
+    if (screen >= PRINT && screen <= PRINT_FINISHED) {
+      queue.enqueue_now_P(PSTR("M22"));
+    }
+  #endif
+
   if (vp.addr == DGUS_Addr::SCREENCHANGE_Idle
       && (printingIsActive() || printingIsPaused())) {
     dgus_screen_handler.SetStatusMessagePGM(PSTR("Impossible while printing"));


### PR DESCRIPTION
### Description

In PR https://github.com/Desuuuu/Marlin/pull/14, we have added the support for boards without SD_DETECT_PIN. This pin can be present but not used in this situation:
https://github.com/MarlinFirmware/Marlin/blob/5ee1087959f88dc60386ff3caa21e75d9e20b128/Marlin/src/inc/Conditionals_post.h#L362-L370

When the SD card is shared with a PC exploiting native USB connection, this portion of code is enabled:
https://github.com/MarlinFirmware/Marlin/blob/5ee1087959f88dc60386ff3caa21e75d9e20b128/Marlin/src/HAL/LPC1768/main.cpp#L143-L155

If i understood well, if we never release the SD card, once it is mounted, it becomes no longer accessible by the connected PC.

### Benefits

This PR aims to avoid this inconvenience.

I'll wait for feedback